### PR TITLE
Update get-random-user-cron-job.yaml

### DIFF
--- a/lab02/get-random-user-cron-job.yaml
+++ b/lab02/get-random-user-cron-job.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:


### PR DESCRIPTION
CronJobs 在 Kubernetes v1.21 之後改成 batch/v1 API